### PR TITLE
Change view to reshape in model forward method

### DIFF
--- a/alibi_testing/modules.py
+++ b/alibi_testing/modules.py
@@ -16,7 +16,7 @@ class CNN(nn.Module):
     def forward(self, x):
         x = F.dropout(F.max_pool2d(F.relu(self.conv1(x)), 2), p=0.3, training=self.training)
         x = F.dropout(F.max_pool2d(F.relu(self.conv2(x)), 2), p=0.3, training=self.training)
-        x = x.view(-1, 1568)
+        x = x.reshape(-1, 1568)
         x = F.dropout(F.relu(self.fc1(x)), p=0.5, training=self.training)
         x = self.fc2(x)
         return x


### PR DESCRIPTION
Update of PyTorch to version 1.12.0 results in the torch CNN model forward method raising the following error:

```
RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
```   

view returns a new view of the same data which requires the data to be contiguous, whereas reshape copies the data if it's not stored contiguously in memory. It seems something in the new version of PyTorch results in non-contiguous data if using:

```py
x = np.zeros((1,) + self.image_shape, dtype=self.dtype)
x = torch.as_tensor(np.moveaxis(x, -1, 1))  # type: ignore
```

and this causes an error where we use `view` in forward.