### PR TITLE
Remove runtime dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,15 @@ Repository for hosting pre-trained models and data loading functions used for te
 Due to the Github 100MB file limit only relatively small models can be stored.
 
 The models are part of the package `alibi-testing`. The package also exposes a single function
-`load(name: str)` at top level for loading pre-trained (currently only TensorFlow) models.
-The intention is to use this package and the `load` functionality as a dependency for running tests for `alibi`.
+`load(name: str)` at top level for loading pre-trained TensorFlow and PyTorch models.
+The intention is to use this package and the `load` functionality as a dependency for running tests for `alibi`
+and `alibi-detect`. 
+
+# Installation
+
+The repo is installed by `alibi` and `alibi-detect` for testing purposes. If installing this repo locally 
+in order to train new models (via the training scripts in `scripts/`), it should be installed by running:
+
+```
+pip install .[training]
+```

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,6 @@ model_files = package_files('alibi_testing/models/')
 # Optional deps. Deps that are already installed by both alibi and alibi-detect do not need to be duplicated here
 extras_require = {
     'training': ['torchvision>=0.10.0, <1.0.0'], # deps required for training, but not to run models
-#    'alibi': [], # deps required by alibi to run the alibi-testing models
-#    'alibi-detect': [], # deps required by alibi-detect to run the alibi-testing models
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -13,11 +13,17 @@ def package_files(directory):
 # load all data files recursively https://stackoverflow.com/a/36693250
 model_files = package_files('alibi_testing/models/')
 
-# Optional deps. Deps that are already installed by both alibi and alibi-detect do not need to be duplicated here
 extras_require = {
-    'training': ['torchvision>=0.10.0, <1.0.0'], # deps required for training, but not to run models
+    'training': [  # deps required for training models
+        'numpy>=1.16.2, <2.0.0',
+        'pandas>=0.23.3, <2.0.0',
+        'requests>=2.21.0, <3.0.0',
+        'scikit-learn>=0.20.2, <2.0.0',
+        'tensorflow>=2.0.0, !=2.6.0, !=2.6.1, <2.11.0',  
+        'torch>=1.9.0, <2.0.0',
+        'torchvision>=0.10.0, <1.0.0'
+    ],
 }
-
 
 setup(
     name='alibi-testing',
@@ -25,6 +31,6 @@ setup(
     packages=find_packages(),
     python_requires='>=3.7',
     extras_require=extras_require,
-    install_requires=[],  # deps installed by both alibi and alibi-detect do not need to be duplicated here
+    install_requires=[],  # alibi and alibi-detect are responsible for installing deps prior to testing
     package_data={'': model_files}
 )

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ extras_require = {
 
 setup(
     name='alibi-testing',
-    version='0.0.11',
+    version='0.1.0',
     packages=find_packages(),
     python_requires='>=3.7',
     extras_require=extras_require,

--- a/setup.py
+++ b/setup.py
@@ -13,19 +13,20 @@ def package_files(directory):
 # load all data files recursively https://stackoverflow.com/a/36693250
 model_files = package_files('alibi_testing/models/')
 
+# Optional deps. Deps that are already installed by both alibi and alibi-detect do not need to be duplicated here
+extras_require = {
+    'training': ['torchvision>=0.10.0, <1.0.0'], # deps required for training, but not to run models
+#    'alibi': [], # deps required by alibi to run the alibi-testing models
+#    'alibi-detect': [], # deps required by alibi-detect to run the alibi-testing models
+}
+
+
 setup(
     name='alibi-testing',
     version='0.0.10',
     packages=find_packages(),
     python_requires='>=3.7',
-    install_requires=[  # deps version bounds are copied from alibi setup.py (and requirements/dev.txt)
-        'numpy>=1.16.2, <2.0.0',
-        'pandas>=0.23.3, <2.0.0',
-        'requests>=2.21.0, <3.0.0',
-        'scikit-learn>=0.20.2, <1.1.0',
-        'tensorflow>=2.0.0, !=2.6.0, !=2.6.1, <2.9.0',  
-        'torch>=1.9.0, <2.0.0',
-        'torchvision>=0.10.0, <1.0.0'
-    ],
+    extras_require=extras_require,
+    install_requires=[],  # deps installed by both alibi and alibi-detect do not need to be duplicated here
     package_data={'': model_files}
 )


### PR DESCRIPTION
This PR proposes to remove runtime deps from `alibi-testing`, so that we do not have to continuously keep them synced with `alibi` and `alibi-detect` (this has been causing issues with dependabot PR's, since the dependabot PR deps are limited by those in `alibi-testing`). 

The core dependencies are made optional, in the `training` `extras_require` bucket. The thinking here is that `alibi` and `alibi-detect` themselves should be responsible for installing the testing deps in `requirements/dev.txt`. The `training` bucket is added so that `alibi-testing` can be installed in a standalone environment to train new models.

The only dependency that is not already a core dep of `alibi` and `alibi-detect` is `torchvision`, who's models are used in some of the `alibi` tests. I don't believe this actually needs to be installed in order to run the `torchvision` models at test time, but if we wanted to be safe we could add `torchvision` to `alibi`'s `requirements/dev.txt`?