### PR TITLE
Remove Boston housing dataset

### DIFF
--- a/alibi_testing/data.py
+++ b/alibi_testing/data.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import requests
 from requests import RequestException
-from sklearn.datasets import load_iris, load_boston
+from sklearn.datasets import load_iris
 from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.model_selection import train_test_split
 from sklearn.compose import ColumnTransformer
@@ -238,28 +238,6 @@ def get_iris_data(seed=42):
             'feature_names': data.feature_names,
             'name': 'iris'
         }
-    }
-
-
-def get_boston_data(seed=42):
-    """
-    Load the Boston housing dataset.
-    """
-    dataset = load_boston()
-    data = dataset.data
-    labels = dataset.target
-    feature_names = dataset.feature_names
-    X_train, X_test, y_train, y_test = train_test_split(data, labels, test_size=0.2, random_state=seed)
-
-    return {
-        'X_train': X_train,
-        'y_train': y_train,
-        'X_test': X_test,
-        'y_test': y_test,
-        'preprocessor': None,
-        'metadata': {
-            'feature_names': feature_names,
-            'name': 'boston'}
     }
 
 


### PR DESCRIPTION
The Boston housing dataset is deprecated from `scikit-learn` in version 1.2 (see https://github.com/scikit-learn/scikit-learn/pull/24603). This PR removes the Boston dataset from `alibi-testing`.